### PR TITLE
NEXT-7802 - fix unnecessary static files from administration in storefront dist folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,10 +184,10 @@ class WebpackPluginInjector {
             : join(basePath, pluginDefinition[section].webpack);
 
         const assetPaths = [];
-        if (pluginDefinition.administration) {
+        if (pluginDefinition.administration && section === 'administration') {
             assetPaths.push(join(basePath, pluginDefinition.administration.path, '../static'));
         }
-        if (pluginDefinition.storefront) {
+        if (pluginDefinition.storefront && section === 'storefront') {
             assetPaths.push(join(basePath, pluginDefinition.storefront.path, '../static'));
         }
 


### PR DESCRIPTION
The webpack pluginjector does not check for which app (Storefront, Admin) is currently being built when creating the assetpaths.

For this reason assets that belong to the admin are copied into the dist folder of the storefront