### PR TITLE
Skip plugin injection by setting envirnoment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,6 +228,12 @@ class WebpackPluginInjector {
             const name = plugin.pluginName;
             const technicalName = plugin.technicalName;
 
+            if (process.env['SKIP_' + technicalName.toUpperCase().replace(/-/g, '_')]) {
+                this.warn('Webpack Plugin Injector', `Skip plugin "${name}" as a new entry point`);
+
+                return;
+            }
+
             // Params for the custom webpack config
             const params = {
                 env: process.env.NODE_ENV,


### PR DESCRIPTION
This pull request adds the possibility to skip plugin injection by setting an environment variables. The environment variables have to be the uppercase representation of the plugin technical name with replaced "-" with "_". 

Example:
```shell
SKIP_NETI_NEXT_EASY_COUPON=true SKIP_NETI_NEXT_EASY_COUPON_DESIGNS=true ./psh.phar storefront:build
```